### PR TITLE
WIP: Add conversational context

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -32,6 +32,11 @@ while [[ "$#" -gt 0 ]]; do
 		shift
 		shift
 		;;
+	-c | --context)
+		CONTEXT=true
+		shift
+		shift
+		;;
 	*)
 		echo "Unknown parameter: $1"
 		exit 1
@@ -44,6 +49,7 @@ TEMPERATURE=${TEMPERATURE:-0.7}
 MAX_TOKENS=${MAX_TOKENS:-1024}
 MODEL=${MODEL:-text-davinci-003}
 SIZE=${SIZE:-512x512}
+CONTEXT=${CONTEXT:-false}
 
 echo -e "Welcome to chatgpt. You can quit with '\033[36mexit\033[0m'."
 running=true
@@ -53,6 +59,9 @@ if [ ! -f ~/.chatgpt_history ]; then
 	touch ~/.chatgpt_history
 	chmod a+rw ~/.chatgpt_history
 fi
+# start new session
+echo "session-`date '+%Y/%m/%d'`-`date '+%H:%M:%S'`">>~/.chatgpt_history
+
 
 while $running; do
 	echo -e "\nEnter a prompt:"
@@ -106,6 +115,17 @@ while $running; do
 		escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g')
 		# escape new lines
 		escaped_prompt=${escaped_prompt//$'\n'/' '}
+
+		if [ "$CONTEXT" = true ]; then
+			init="You are a Large Language Model created by OpenAI. You are having a chat with a user and must be very helpful, clear and consise in your answers. Use no more than 6 bullet points when you have long answers to give. You were trained on data up until 2021"
+			chat_context=$(sed '/session-/h;//!H;$!d;x' ~/.chatgpt_history)
+			chat_context=${chat_context//$'\n'/' '}
+			chat_context=$(echo "$chat_context" | sed 's/"/\\"/g')
+
+			escaped_prompt="$init $chat_context $escaped_prompt"
+		fi
+
+		echo -e $MODEL $escaped_prompt
 		# request to OpenAI API
 		response=$(curl https://api.openai.com/v1/completions \
 			-sS \
@@ -117,12 +137,12 @@ while $running; do
   			"max_tokens": '$MAX_TOKENS',
   			"temperature": '$TEMPERATURE'
 			}')
-
+		echo $response
 		handleError "$response"
 		response_data=$(echo $response | jq -r '.choices[].text' | sed '1,2d')
 		echo -e "\n\033[36mchatgpt \033[0m${response_data}"
 
 		timestamp=$(date +"%d/%m/%Y %H:%M")
-		echo -e "$timestamp $prompt \n$response_data \n" >>~/.chatgpt_history
+		echo -e "$timestamp Q:$prompt \nA:$response_data \n" >>~/.chatgpt_history
 	fi
 done


### PR DESCRIPTION
- Chat context mode can be enabled by starting the script with `-c` parameter
- ~Every time chatgpt script starts with `-c`, a new session is created in history file~
- Sending chat session history in each prompt in form of Q&A
- Using a prompt to instruct the model to act like ChatGTP and take into account the chat history
- If the chat context becomes too large, the oldest Q&As are dropped
