### PR TITLE
Shell useage

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-#CHAT_INIT_PROMPT="You are ChatGPT, a Large Language Model trained by OpenAI. You will be answering questions from users. You answer as concisely as possible for each response (e.g. don’t be verbose). If you are generating a list, do not have too many items. Keep the number of items short. Before each user prompt you will be given the chat history in Q&A form. Output your answer directly, with no labels in front. Do not start your answers with A or Anwser. You were trained on data up until 2021. Today's date is $(date +%d/%m/%Y)"
-CHAT_INIT_PROMPT="Du bist ChatGPT und bekommst Benutzeranfragen direkt aus eine Linux Shell heraus. Beschränke dich auf das wesentliche und gib nützliche Tipps. Setze deine vorgeschlagenen Scripte, Kommandos und Befehle nicht in Anführungszeichen. Füge Kommentaren an den entscheidenden Stellen ein. Der Anfrage wird der Chatverlauf im Q&A Format voran gestellt."
+CHAT_INIT_PROMPT="You are ChatGPT, a Large Language Model trained by OpenAI. You will be answering questions from users. You answer as concisely as possible for each response (e.g. don’t be verbose). If you are generating a list, do not have too many items. Keep the number of items short. Before each user prompt you will be given the chat history in Q&A form. Output your answer directly, with no labels in front. Do not start your answers with A or Anwser. You were trained on data up until 2021. Today's date is $(date +%d/%m/%Y)"
 CHATGPT_PROMPT="\n\033[36mchatgpt \033[0m"
 
 # Error handling function
@@ -125,43 +124,6 @@ while [[ "$#" -gt 0 ]]; do
 		CONTEXT=true
 		shift
 		;;
-	--test)
-		test=true
-		shift
-		;;
-	-h|--help)
-	echo 'chatgpt [parameter]
-
-CLI is running if prompt not insert from file, string or stdin.
-
-Usage Parameter:
- -c, --chat-context	i.e. chatgpt --chat-context and start to chat normally. 
- -i, --init-prompt-from-file
- --init-prompt		Overwrite Initial prompt
- -p, --prompt-from-file
- --prompt
- --test		Only prompt parameters
- 
-Request Parameters:
- -t, --temperature
- -m, --model
- --max-tokens
- -s, --size		256x256, 512x512, 1024x1024
-
-CLI Commands:
-
-image: To generate images, start a prompt with image: If you are using iTerm, you can view the image directly in the terminal. Otherwise the script will ask to open the image in your browser.
- 
-history To view your chat history, type history
- 
-models To get a list of the models available at OpenAI API, type models
- 
-model: To view all the information on a specific model, start a prompt with model: and the model id as it appears in the list of models. For example: model:text-babbage:001 will get you all the fields for text-babbage:001 model
- 
-exit
-'
-		exit 0
-		;;
 	*)
 		echo "Unknown parameter: $1"
 		exit 1
@@ -170,12 +132,10 @@ exit
 done
 
 
-# Prüfen, ob die Eingabe über eine Pipe oder eine Datei empfangen wird
+# Check if the input comes from stdin
 if [ -p /dev/stdin ]; then
- # Eingabe über eine Pipe empfangen
  prompt+=$(cat -)
 fi
-
 
 # set defaults
 TEMPERATURE=${TEMPERATURE:-0.7}
@@ -203,21 +163,11 @@ while $running; do
 			read prompt
 		fi	
 	else
+		CHATGPT_PROMPT=""
 		running=false
 	fi
 
-	if [ $test ]; then
-		echo "Parameter Test"
-		echo '	"model": "'"$MODEL"'"
-	"init_prompt": '$CHAT_INIT_PROMPT'
-	"prompt": '$prompt'
-	"max_tokens": '$MAX_TOKENS'
-	"temperature": '$TEMPERATURE'
-	"size": '$SIZE'
-	"context": '$CONTEXT'
-	'
-		running=false
-	elif [ "$prompt" == "exit" ]; then
+	if [ "$prompt" == "exit" ]; then
 		running=false
 	elif [[ "$prompt" =~ ^image: ]]; then
 		request_to_image "$prompt"

--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-CHAT_INIT_PROMPT="You are ChatGPT, a Large Language Model trained by OpenAI. You will be answering questions from users. You answer as concisely as possible for each response (e.g. don’t be verbose). If you are generating a list, do not have too many items. Keep the number of items short. Before each user prompt you will be given the chat history in Q&A form. Output your answer directly, with no labels in front. Do not start your answers with A or Anwser. You were trained on data up until 2021. Today's date is $(date +%d/%m/%Y)"
+#CHAT_INIT_PROMPT="You are ChatGPT, a Large Language Model trained by OpenAI. You will be answering questions from users. You answer as concisely as possible for each response (e.g. don’t be verbose). If you are generating a list, do not have too many items. Keep the number of items short. Before each user prompt you will be given the chat history in Q&A form. Output your answer directly, with no labels in front. Do not start your answers with A or Anwser. You were trained on data up until 2021. Today's date is $(date +%d/%m/%Y)"
+CHAT_INIT_PROMPT="Du bist ChatGPT und bekommst Benutzeranfragen direkt aus eine Linux Shell heraus. Beschränke dich auf das wesentliche und gib nützliche Tipps. Setze deine vorgeschlagenen Scripte, Kommandos und Befehle nicht in Anführungszeichen. Füge Kommentaren an den entscheidenden Stellen ein. Der Anfrage wird der Chatverlauf im Q&A Format voran gestellt."
+CHATGPT_PROMPT="\n\033[36mchatgpt \033[0m"
 
 # Error handling function
 # $1 should be the response body
@@ -79,6 +81,26 @@ maintain_chat_context() {
 # parse command line arguments
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
+	-i | --init-prompt-from-file)
+		CHAT_INIT_PROMPT=$(cat "$2")
+		shift
+		shift
+		;;
+	--init-prompt)
+		CHAT_INIT_PROMPT="$2"
+		shift
+		shift
+		;;
+	-p | --prompt-from-file)
+		prompt=$(cat "$2")
+		shift
+		shift
+		;;
+	--prompt)
+		prompt="$2"
+		shift
+		shift
+		;;
 	-t | --temperature)
 		TEMPERATURE="$2"
 		shift
@@ -102,7 +124,43 @@ while [[ "$#" -gt 0 ]]; do
 	-c | --chat-context)
 		CONTEXT=true
 		shift
+		;;
+	--test)
+		test=true
 		shift
+		;;
+	-h|--help)
+	echo 'chatgpt [parameter]
+
+CLI is running if prompt not insert from file, string or stdin.
+
+Usage Parameter:
+ -c, --chat-context	i.e. chatgpt --chat-context and start to chat normally. 
+ -i, --init-prompt-from-file
+ --init-prompt		Overwrite Initial prompt
+ -p, --prompt-from-file
+ --prompt
+ --test		Only prompt parameters
+ 
+Request Parameters:
+ -t, --temperature
+ -m, --model
+ --max-tokens
+ -s, --size		256x256, 512x512, 1024x1024
+
+CLI Commands:
+
+image: To generate images, start a prompt with image: If you are using iTerm, you can view the image directly in the terminal. Otherwise the script will ask to open the image in your browser.
+ 
+history To view your chat history, type history
+ 
+models To get a list of the models available at OpenAI API, type models
+ 
+model: To view all the information on a specific model, start a prompt with model: and the model id as it appears in the list of models. For example: model:text-babbage:001 will get you all the fields for text-babbage:001 model
+ 
+exit
+'
+		exit 0
 		;;
 	*)
 		echo "Unknown parameter: $1"
@@ -111,14 +169,23 @@ while [[ "$#" -gt 0 ]]; do
 	esac
 done
 
+
+# Prüfen, ob die Eingabe über eine Pipe oder eine Datei empfangen wird
+if [ -p /dev/stdin ]; then
+ # Eingabe über eine Pipe empfangen
+ prompt+=$(cat -)
+fi
+
+
 # set defaults
 TEMPERATURE=${TEMPERATURE:-0.7}
 MAX_TOKENS=${MAX_TOKENS:-1024}
 MODEL=${MODEL:-text-davinci-003}
 SIZE=${SIZE:-512x512}
 CONTEXT=${CONTEXT:-false}
+USER=${USER:-Human}
 
-echo -e "Welcome to chatgpt. You can quit with '\033[36mexit\033[0m'."
+[ -z "$prompt" ] && echo -e "Welcome to chatgpt. You can quit with '\033[36mexit\033[0m'."
 running=true
 
 # create history file
@@ -128,16 +195,35 @@ if [ ! -f ~/.chatgpt_history ]; then
 fi
 
 while $running; do
-	echo -e "\nEnter a prompt:"
-	read prompt
+	if [ -z "$prompt" ]; then
+		if type -P rlwrap &> /dev/null; then
+				prompt=$(rlwrap -pYellow -S "[${USER}] " -H past_orders -o cat)
+		else
+			echo -e "\nEnter a prompt:"
+			read prompt
+		fi	
+	else
+		running=false
+	fi
 
-	if [ "$prompt" == "exit" ]; then
+	if [ $test ]; then
+		echo "Parameter Test"
+		echo '	"model": "'"$MODEL"'"
+	"init_prompt": '$CHAT_INIT_PROMPT'
+	"prompt": '$prompt'
+	"max_tokens": '$MAX_TOKENS'
+	"temperature": '$TEMPERATURE'
+	"size": '$SIZE'
+	"context": '$CONTEXT'
+	'
+		running=false
+	elif [ "$prompt" == "exit" ]; then
 		running=false
 	elif [[ "$prompt" =~ ^image: ]]; then
 		request_to_image "$prompt"
 		handle_error "$image_response"
 		image_url=$(echo $image_response | jq -r '.data[0].url')
-		echo -e "\n\033[36mchatgpt \033[0mYour image was created. \n\nLink: ${image_url}\n"
+		echo -e "${CHATGPT_PROMPT} Your image was created. \n\nLink: ${image_url}\n"
 
 		if [[ "$TERM_PROGRAM" == "iTerm.app" ]]; then
 			curl -sS $image_url -o temp_image.png
@@ -158,14 +244,14 @@ while $running; do
 			-H "Authorization: Bearer $OPENAI_KEY")
 		handle_error "$models_response"
 		models_data=$(echo $models_response | jq -r -C '.data[] | {id, owned_by, created}')
-		echo -e "\n\033[36mchatgpt \033[0m This is a list of models currently available at OpenAI API:\n ${models_data}"
+		echo -e "${CHATGPT_PROMPT} This is a list of models currently available at OpenAI API:\n ${models_data}"
 	elif [[ "$prompt" =~ ^model: ]]; then
 		models_response=$(curl https://api.openai.com/v1/models \
 			-sS \
 			-H "Authorization: Bearer $OPENAI_KEY")
 		handle_error "$models_response"
 		model_data=$(echo $models_response | jq -r -C '.data[] | select(.id=="'"${prompt#*model:}"'")')
-		echo -e "\n\033[36mchatgpt \033[0m Complete details for model: ${prompt#*model:}\n ${model_data}"
+		echo -e "${CHATGPT_PROMPT} Complete details for model: ${prompt#*model:}\n ${model_data}"
 	else
 		# escape quotation marks
 		escaped_prompt=$(echo "$prompt" | sed 's/"/\\"/g')
@@ -179,7 +265,7 @@ while $running; do
 		request_to_completions "$request_prompt"
 		handle_error "$response"
 		response_data=$(echo $response | jq -r '.choices[].text' | sed '1,2d; s/^A://g')
-		echo -e "\n\033[36mchatgpt \033[0m${response_data}"
+		echo -e "${CHATGPT_PROMPT} ${response_data}"
 
 		if [ "$CONTEXT" = true ]; then
 			maintain_chat_context "$chat_context" "$response_data"
@@ -188,4 +274,5 @@ while $running; do
 		timestamp=$(date +"%d/%m/%Y %H:%M")
 		echo -e "$timestamp $prompt \n$response_data \n" >>~/.chatgpt_history
 	fi
+	prompt=""
 done


### PR DESCRIPTION
Hi. This add support to use the scrtipt directly from shell to return response without open cli. So you can use it on other scripts.
Added parameters:
**-i | --init-prompt-from-file**) # if you need multiple Initprompts
**--init-prompt**) # or just a small init-promt
**-p | --prompt-from-file**) # put prompt from file
**--prompt**) # or directly in command parameter

You can send the prompt directly through a pipe.

> echo "Hello GPT" | chatgpt

Additional check rlwrap to add navigation support for the cli.
I hope theres nothing wrong, it is my first pull request. 