### PR TITLE
Allow input from redirected stdin

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -216,15 +216,16 @@ fi
 
 running=true
 # check input source
+# prompt from argument
+if [ -n "$prompt" ]; then
+	pipe_mode_prompt=${prompt}
+# if input file_descriptor is a terminal
+elif [ -t 0 ]; then
+	echo -e "Welcome to chatgpt. You can quit with '\033[36mexit\033[0m'."
 # if prompt already entered, run on pipe mode (run once, no chat)
 # prompt from pipe
-if [ -p /dev/stdin ]; then
-	pipe_mode_prompt+=$(cat -)
-# prompt from argument
-elif [ -n "$prompt" ]; then
-	pipe_mode_prompt=${prompt}
 else
-	echo -e "Welcome to chatgpt. You can quit with '\033[36mexit\033[0m'."
+	pipe_mode_prompt+=$(cat -)
 fi
 
 while $running; do


### PR DESCRIPTION
This change fixes redirected stdin. For example, consider we have a `query` file:

```
How are you doing?
```

Before:

```
chatgpt <query 
Welcome to chatgpt. You can quit with 'exit'.

Enter a prompt:
(waits for prompt)
```

After: (expected)

```
chatgpt <query 
As an AI language model, I don't have feelings, but I'm functioning well and ready to assist you with any questions or tasks you have.
```

PS: Pipes still work as expected:

```
$ echo "How are you doing?" | chatgpt 
As an AI language model, I do not have feelings, but I am functioning properly and ready to assist you with any questions or tasks you may have.
```

PS2: This empowers use cases such as this:

![Screen Recording 2023-03-17 at 07 41 25](https://user-images.githubusercontent.com/967155/225883525-e9697361-d8f4-4985-be2f-d4597eb7cce0.gif)

![Screen Recording 2023-03-17 at 07 43 36](https://user-images.githubusercontent.com/967155/225883654-c8d50162-7c78-4f05-9055-a8358cc50642.gif)
