### PR TITLE
Restricted history file permission

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -211,7 +211,7 @@ CONTEXT=${CONTEXT:-false}
 # create history file
 if [ ! -f ~/.chatgpt_history ]; then
 	touch ~/.chatgpt_history
-	chmod a+rw ~/.chatgpt_history
+	chmod 600 ~/.chatgpt_history
 fi
 
 running=true


### PR DESCRIPTION
This change makes ~/.chatgpt_history accessible (read & write) only for its owner.