### PR TITLE
Add .zshrc to install script, since it was missing.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,14 @@ if [ "$answer" == "Yes" ] || [ "$answer" == "yes" ] || [ "$answer" == "y" ] || [
     echo 'export PATH=$PATH:/usr/local/bin' >>~/.zprofile
     echo "OpenAI key and chatgpt path added to ~/.zprofile"
     source ~/.zprofile
+  # zshrc profile, used for interactive shells in linux
+  elif [ -f ~/.zshrc ]; then
+    echo "export OPENAI_KEY=$key" >>~/.zshrc
+    if [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+      echo 'export PATH=$PATH:/usr/local/bin' >>~/.zshrc
+    fi
+    echo "OpenAI key and chatgpt path added to ~/.zshrc"
+    source ~/.zshrc
   # bash profile mac
   elif [ -f ~/.bash_profile ]; then
     echo "export OPENAI_KEY=$key" >>~/.bash_profile


### PR DESCRIPTION
Add check for `.zshrc` after `.zprofile` to enable installing on a wider linux platform base. Also Make it so that `$PATH` is not modified if `usr/local/bin` already exists on path in `.zshrc`. (Added a new PR to make this default on other install methods as well).

Problem: 

The install script fails if there is only .zshrc but no .zprofile. This is a common setup as .zshrc is actually the place to declare packages etc. for use in any interactive shell and .zprofile is supposed to be only for login shells: [See unix.stackexchange discussion](https://unix.stackexchange.com/questions/71253/what-should-shouldnt-go-in-zshenv-zshrc-zlogin-zprofile-zlogout).