### PR TITLE
Only prepend /usr/local/bin to $PATH if its not already there.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,19 +48,25 @@ if [ "$answer" == "Yes" ] || [ "$answer" == "yes" ] || [ "$answer" == "y" ] || [
   # zsh profile
   if [ -f ~/.zprofile ]; then
     echo "export OPENAI_KEY=$key" >>~/.zprofile
-    echo 'export PATH=$PATH:/usr/local/bin' >>~/.zprofile
+    if [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+      echo 'export PATH=$PATH:/usr/local/bin' >>~/.zprofile
+    fi
     echo "OpenAI key and chatgpt path added to ~/.zprofile"
     source ~/.zprofile
   # bash profile mac
   elif [ -f ~/.bash_profile ]; then
     echo "export OPENAI_KEY=$key" >>~/.bash_profile
-    echo 'export PATH=$PATH:/usr/local/bin' >>~/.bash_profile
+    if [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+      echo 'export PATH=$PATH:/usr/local/bin' >>~/.bash_profile
+    fi
     echo "OpenAI key and chatgpt path added to ~/.bash_profile"
     source ~/.bash_profile
   # profile ubuntu
   elif [ -f ~/.profile ]; then
     echo "export OPENAI_KEY=$key" >>~/.profile
-    echo 'export PATH=$PATH:/usr/local/bin' >>~/.profile
+    if [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+      echo 'export PATH=$PATH:/usr/local/bin' >>~/.profile
+    fi
     echo "OpenAI key and chatgpt path added to ~/.profile"
     source ~/.profile
   else

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ if [ "$answer" == "Yes" ] || [ "$answer" == "yes" ] || [ "$answer" == "y" ] || [
   # zsh profile
   if [ -f ~/.zprofile ]; then
     echo "export OPENAI_KEY=$key" >>~/.zprofile
-    if [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+    if [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
       echo 'export PATH=$PATH:/usr/local/bin' >>~/.zprofile
     fi
     echo "OpenAI key and chatgpt path added to ~/.zprofile"
@@ -56,7 +56,7 @@ if [ "$answer" == "Yes" ] || [ "$answer" == "yes" ] || [ "$answer" == "y" ] || [
   # bash profile mac
   elif [ -f ~/.bash_profile ]; then
     echo "export OPENAI_KEY=$key" >>~/.bash_profile
-    if [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+    if [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
       echo 'export PATH=$PATH:/usr/local/bin' >>~/.bash_profile
     fi
     echo "OpenAI key and chatgpt path added to ~/.bash_profile"
@@ -64,7 +64,7 @@ if [ "$answer" == "Yes" ] || [ "$answer" == "yes" ] || [ "$answer" == "y" ] || [
   # profile ubuntu
   elif [ -f ~/.profile ]; then
     echo "export OPENAI_KEY=$key" >>~/.profile
-    if [[ ":$PATH:" == *":/usr/local/bin:"* ]]; then
+    if [[ ":$PATH:" != *":/usr/local/bin:"* ]]; then
       echo 'export PATH=$PATH:/usr/local/bin' >>~/.profile
     fi
     echo "OpenAI key and chatgpt path added to ~/.profile"


### PR DESCRIPTION
During install, only prepend /usr/local/bin to $PATH if its not already in the $PATH.

Problem:

As many commons scripts already add /usr/local/bin it to path, we do not want to overwrite these, especially since it may cause PATH conflicts.

For example brew or conda might have preferences for this not being the first entry, but might already add it. So do not overwrite the path with such a destructive choice if we can already find /usr/local/bin in Path. Only add it if we do not find it.