### PR TITLE
Add $CHATGPT_PLUMBER env to change the default command for opening images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ This script relies on curl for the requests to the api and jq to parse the json 
 
   - `image:` To generate images, start a prompt with `image:`
     If you are using iTerm, you can view the image directly in the terminal. Otherwise the script will ask to open the image in your browser.
+    
+    `open` is used as a plumber by default to open the image. You can set $CHATGPT_PLUMBER to change it.
+
   - `history` To view your chat history, type `history`
   - `models` To get a list of the models available at OpenAI API, type `models`
   - `model:` To view all the information on a specific model, start a prompt with `model:` and the model `id` as it appears in the list of models. For example: `model:text-babbage:001` will get you all the fields for `text-babbage:001` model

--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -259,7 +259,11 @@ while $running; do
 			echo "Would you like to open it? (Yes/No)"
 			read -e answer
 			if [ "$answer" == "Yes" ] || [ "$answer" == "yes" ] || [ "$answer" == "y" ] || [ "$answer" == "Y" ] || [ "$answer" == "ok" ]; then
-				open "${image_url}"
+				if [[ -z "${CHATGPT_PLUMBER}" ]]; then
+					open "${image_url}"
+				else
+					$CHATGPT_PLUMBER "${image_url}"
+				fi
 			fi
 		fi
 	elif [[ "$prompt" == "history" ]]; then


### PR DESCRIPTION
This PR add $CHATGPT_PLUMBER env to change the default command for opening images, while keeping `open` as the default command. 


The PR #33 fixed this issue for the `install.sh` script. But this PR is useful for manually installing the script.
