### PR TITLE
Minor improvements to prompting

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -7,7 +7,7 @@ SYSTEM_PROMPT="You are ChatGPT, a large language model trained by OpenAI. Answer
 
 COMMAND_GENERATION_PROMPT="Return a one-line bash command with the functionality I will describe. Return ONLY the command ready to run in the terminal. The command should do the following:"
 
-CHATGPT_CYAN_LABEL="\n\033[36mchatgpt \033[0m"
+CHATGPT_CYAN_LABEL="\e[36mchatgpt: \e[0m"
 
 # error handling function
 # $1 should be the response body

--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -9,6 +9,8 @@ COMMAND_GENERATION_PROMPT="Return a one-line bash command with the functionality
 
 CHATGPT_CYAN_LABEL="\e[36mchatgpt: \e[0m"
 
+REQUEST_SENT_LABEL="\e[90mprocessing...\e[0m"
+
 USER_GREEN_LABEL="\n\e[32mprompt: \e[0m"
 
 # error handling function
@@ -247,7 +249,10 @@ while $running; do
 
 	if [ "$prompt" == "exit" ] || [ "$prompt" == "q" ]; then
 		running=false
-	elif [[ "$prompt" =~ ^image: ]]; then
+	fi
+
+	echo -e "${REQUEST_SENT_LABEL}"
+	if [[ "$prompt" =~ ^image: ]]; then
 		request_to_image "$prompt"
 		handle_error "$image_response"
 		image_url=$(echo $image_response | jq -r '.data[0].url')

--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -9,6 +9,8 @@ COMMAND_GENERATION_PROMPT="Return a one-line bash command with the functionality
 
 CHATGPT_CYAN_LABEL="\e[36mchatgpt: \e[0m"
 
+USER_GREEN_LABEL="\n\e[32mprompt: \e[0m"
+
 # error handling function
 # $1 should be the response body
 handle_error() {
@@ -234,7 +236,7 @@ fi
 while $running; do
 
 	if [ -z "$pipe_mode_prompt" ]; then
-		echo -e "\nEnter a prompt:"
+		echo -n -e "${USER_GREEN_LABEL}"
 		read -e prompt
 	else
 		# set vars for pipe mode


### PR DESCRIPTION
This PR contains some minor improvements to the prompt, namely:

- Changing the prompt text to `prompt:` to make it more visually aligned with the ChatGPT response prompt (`chatgpt:`).
- Makes the input prompt green to contrast with ChatGPT's cyan response prompt
- Prints `processing...` (in dark gray text) when a request has been sent

Here's a preview of how it looks:

![Screenshot from 2023-04-04 11-53-01](https://user-images.githubusercontent.com/16208985/229758659-3fa800d6-286c-4333-8be2-850f26116f61.png)
