### PR TITLE
Wrap output to terminal width

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -324,7 +324,7 @@ while $running; do
 		handle_error "$response"
 		response_data=$(echo "$response" | jq -r '.choices[].message.content')
 
-		echo -e "${CHATGPT_CYAN_LABEL}${response_data}"
+		echo -e "${CHATGPT_CYAN_LABEL}${response_data}" | fold -s -w $COLUMNS
 
 		escaped_response_data=$(echo "$response_data" | sed 's/"/\\"/g')
 		add_assistant_response_to_chat_message "$chat_message" "$escaped_response_data"


### PR DESCRIPTION
This should improve readability of ChatGPT's responses. Example output:
![Screenshot from 2023-04-04 13-55-52](https://user-images.githubusercontent.com/16208985/229784061-281bc163-c22e-4315-9157-05ea42ec8ec5.png)
