### PR TITLE
Prompting improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,5 +151,5 @@ This script relies on curl for the requests to the api and jq to parse the json 
 ## Contributors
 :pray: Thanks to all the people who used, tested, submitted issues, PRs and proposed changes:
 
-[pfr-dev](https://www.github.com/pfr-dev), [jordantrizz](https://www.github.com/jordantrizz), [se7en-x230](https://www.github.com/se7en-x230), [mountaineerbr](https://www.github.com/mountaineerbr), [oligeo](https://www.github.com/oligeo), [biaocy](https://www.github.com/biaocy), [dmd](https://www.github.com/dmd), [goosegit11](https://www.github.com/goosegit11), [dilatedpupils](https://www.github.com/dilatedpupils), [direster](https://www.github.com/direster), [rxaviers](https://www.github.com/rxaviers), [Zeioth](https://www.github.com/Zeioth)
+[pfr-dev](https://www.github.com/pfr-dev), [jordantrizz](https://www.github.com/jordantrizz), [se7en-x230](https://www.github.com/se7en-x230), [mountaineerbr](https://www.github.com/mountaineerbr), [oligeo](https://www.github.com/oligeo), [biaocy](https://www.github.com/biaocy), [dmd](https://www.github.com/dmd), [goosegit11](https://www.github.com/goosegit11), [dilatedpupils](https://www.github.com/dilatedpupils), [direster](https://www.github.com/direster), [rxaviers](https://www.github.com/rxaviers), [Zeioth](https://www.github.com/Zeioth), [edshamis](https://www.github.com/edshamis)
 


### PR DESCRIPTION
@nre-ableton Thank you for your contribution! 👍 
I wanted to include your changes, that's why I added them to my branch, but unfortunately run into some issues testing.

The `\e` did not work on my zsh/iterm so I had to keep the old `\033 code`. I believe this to be more compatible with other shells.
About the colored prompt, I am very hesitant to add another color to the UI. I believe it should be as minimal as possible.
I had some issues with the processing label, running even when you type exit and sending a request, so I concluded to the solution you see in https://github.com/0xacx/chatGPT-shell-cli/pull/77
Thank you very much for taking the time and implementing improvements! Much appreciated!