### PR TITLE
fix: multiline file prompt input

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -97,7 +97,7 @@ request_to_image() {
 request_to_chat() {
 	message="$1"
 	# escape quotation marks and newlines in the prompt
-	escaped_prompt=$(echo "$SYSTEM_PROMPT" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+	escaped_system_prompt=$(echo "$SYSTEM_PROMPT" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
 	response=$(curl https://api.openai.com/v1/chat/completions \
 		-sS \
 		-H 'Content-Type: application/json' \

--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -96,6 +96,8 @@ request_to_image() {
 # $1 should be the message(s) formatted with role and content
 request_to_chat() {
 	message="$1"
+	# escape quotation marks and newlines in the prompt
+	escaped_prompt=$(echo "$SYSTEM_PROMPT" | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
 	response=$(curl https://api.openai.com/v1/chat/completions \
 		-sS \
 		-H 'Content-Type: application/json' \
@@ -103,7 +105,7 @@ request_to_chat() {
 		-d '{
             "model": "'"$MODEL"'",
             "messages": [
-                {"role": "system", "content": "'"$SYSTEM_PROMPT"'"},
+                {"role": "system", "content": "'"$escaped_prompt"'"},
                 '"$message"'
                 ],
             "max_tokens": '$MAX_TOKENS',


### PR DESCRIPTION
Fixing issue:
- execution with the flag `--init-prompt-from-file` and using a file that contains newlines. Those are replaced with `\n` which should be fine according to [this discussion](https://community.openai.com/t/chatgpt-api-messages-with-line-breaks/80661)