### PR TITLE
Fix date format and timestamp

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -2,9 +2,9 @@
 
 GLOBIGNORE="*"
 
-CHAT_INIT_PROMPT="You are ChatGPT, a Large Language Model trained by OpenAI. You will be answering questions from users. You answer as concisely as possible for each response (e.g. don’t be verbose). If you are generating a list, do not have too many items. Keep the number of items short. Before each user prompt you will be given the chat history in Q&A form. Output your answer directly, with no labels in front. Do not start your answers with A or Anwser. You were trained on data up until 2021. Today's date is $(date +%d/%m/%Y)"
+CHAT_INIT_PROMPT="You are ChatGPT, a Large Language Model trained by OpenAI. You will be answering questions from users. You answer as concisely as possible for each response (e.g. don’t be verbose). If you are generating a list, do not have too many items. Keep the number of items short. Before each user prompt you will be given the chat history in Q&A form. Output your answer directly, with no labels in front. Do not start your answers with A or Anwser. You were trained on data up until 2021. Today's date is $(date +%m/%d/%Y)"
 
-SYSTEM_PROMPT="You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible. Current date: $(date +%d/%m/%Y). Knowledge cutoff: 9/1/2021."
+SYSTEM_PROMPT="You are ChatGPT, a large language model trained by OpenAI. Answer as concisely as possible. Current date: $(date +%m/%d/%Y). Knowledge cutoff: 9/1/2021."
 
 COMMAND_GENERATION_PROMPT="You are a Command Line Interface expert and your task is to provide functioning shell commands. Return a CLI command and nothing else - do not send it in a code block, quotes, or anything else, just the pure text CONTAINING ONLY THE COMMAND. If possible, return a one-line bash command or chain many commands together. Return ONLY the command ready to run in the terminal. The command should do the following:"
 
@@ -356,7 +356,7 @@ while $running; do
 		fi
 		add_assistant_response_to_chat_message "$(escape "$response_data")"
 
-		timestamp=$(date +"%d/%m/%Y %H:%M")
+		timestamp=$(date +"%Y-%m-%d %H:%M")
 		echo -e "$timestamp $prompt \n$response_data \n" >>~/.chatgpt_history
 
 	elif [[ "$MODEL" =~ ^gpt- ]]; then
@@ -379,7 +379,7 @@ while $running; do
 		fi
 		add_assistant_response_to_chat_message "$(escape "$response_data")"
 
-		timestamp=$(date +"%d/%m/%Y %H:%M")
+		timestamp=$(date +"%Y-%m-%d %H:%M")
 		echo -e "$timestamp $prompt \n$response_data \n" >>~/.chatgpt_history
 	else
 		# escape quotation marks, new lines, backslashes...
@@ -408,7 +408,7 @@ while $running; do
 			maintain_chat_context "$(escape "$response_data")"
 		fi
 
-		timestamp=$(date +"%d/%m/%Y %H:%M")
+		timestamp=$(date +"%Y-%m-%d %H:%M")
 		echo -e "$timestamp $prompt \n$response_data \n" >>~/.chatgpt_history
 	fi
 done


### PR DESCRIPTION
Update the date format used in the `CHAT_INIT_PROMPT` and `SYSTEM_PROMPT` variables from `dd/mm/yyyy` to `mm/dd/yyyy` since it's implied it's written on English language.

Additionally, the date format used in the `timestamp` variable was changed from `dd/mm/yyyy HH:MM` to ISO format `yyyy-mm-dd HH:MM`.