### PR TITLE
Start each script with `#!/usr/bin/env bash`

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 GLOBIGNORE="*"
 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ $EUID -ne 0 ]]; then
   echo "This script must be run as root"

--- a/internal_dev/debmaker.sh
+++ b/internal_dev/debmaker.sh
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 ###############################################################################
 # Purpose: The purpose of this script is to simply generate a .deb file.
 # Once the .deb file is generated a copy is moved to /tmp.


### PR DESCRIPTION
On NixOS `#!/bin/bash` at the start of a script fails, since the bash is somewhere in `/nix/store/`. We start each script with `#!/usr/bin/env bash` since that's supported by most distros AFAIK.