### PR TITLE
add a new command "recall"

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -366,6 +366,23 @@ while $running; do
 		echo -e "\n$(cat ~/.chatgpt_history)"
 	elif [[ "$prompt" == "models" ]]; then
 		list_models
+	elif [[ "$prompt" =~ ^recall: ]]; then
+		recall_prompts=${prompt#recall:}
+		file_contents=$(cat ~/.chatgpt_history)
+		print_block=false
+		while read -r line
+		do
+			if [[ $line =~ ^[0-9]{2}/[0-9]{2}/[0-9]{4} ]]; then
+				if [[ $line =~ $recall_prompts ]]; then
+					echo -e "$line"
+					print_block=true
+				else
+					print_block=false
+				fi
+			elif [ "$print_block" = true ]; then
+				echo -e "$line"
+			fi
+		done <<< "$file_contents"
 	elif [[ "$prompt" =~ ^model: ]]; then
 		models_response=$(curl https://api.openai.com/v1/models \
 			-sS \

--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -367,18 +367,20 @@ while $running; do
 	elif [[ "$prompt" == "models" ]]; then
 		list_models
 	elif [[ "$prompt" =~ ^recall: ]]; then
-		recall_prompts=${prompt#recall:}
+		recall_prompts=(${prompt#recall:})
 		file_contents=$(cat ~/.chatgpt_history)
 		print_block=false
 		while read -r line
 		do
 			if [[ $line =~ ^[0-9]{2}/[0-9]{2}/[0-9]{4} ]]; then
-				if [[ $line =~ $recall_prompts ]]; then
-					echo -e "$line"
-					print_block=true
-				else
-					print_block=false
-				fi
+				for recall_word in "${recall_prompts[@]}"; do
+					if ! [[ $line =~ $recall_word ]]; then
+						print_block=false
+						continue 2
+					fi
+				done
+				print_block=true
+				echo -e "$line"
 			elif [ "$print_block" = true ]; then
 				echo -e "$line"
 			fi


### PR DESCRIPTION
new recall command: 
Query the chat_history file and echo the matched conversations

usage:
recall:query_word1 query_word2 ...

The query words only matches the question you ask to chatgpt. It doesn't match the answers which containes the query word without query word in question