### PR TITLE
Update help text for multi-line support parameter

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -44,7 +44,7 @@ Options:
 
   --prompt-from-file         Provide prompt from file
 
-  -b, --big-prompt           Allow multi-line prompts during chat mode
+  --multi-line-prompt        Allow multi-line prompts during chat mode
 
   -t, --temperature          Temperature
 


### PR DESCRIPTION
Current helper text shows:
```
b, --big-prompt
```

Should be:
```
--multi-line-prompt
```