### PR TITLE
Allow specifying $OPENAI_API_KEY_PATH as a file path to a text file containing OpenAI Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This script relies on curl for the requests to the api and jq to parse the json 
 
   - Download the `chatgpt.sh` file in a directory you want
   - Add the path of `chatgpt.sh` to your `$PATH`. You do that by adding this line to your shell profile: `export PATH=$PATH:/path/to/chatgpt.sh`
-  - Add the OpenAI API key to your shell profile by adding this line `export OPENAI_KEY=your_key_here`
+  - Add the OpenAI API key to your shell profile by adding this line `export OPENAI_KEY=your_key_here` or by specifying a key file by adding this line `export OPENAI_API_KEY_PATH=/path/to/your/key.txt`
   - If you are using iTerm and want to view images in terminal, install [imgcat](https://iterm2.com/utilities/imgcat)
 
 ## Usage

--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -12,9 +12,16 @@ CHATGPT_CYAN_LABEL="\033[36mchatgpt \033[0m"
 PROCESSING_LABEL="\n\033[90mProcessing... \033[0m\033[0K\r"
 OVERWRITE_PROCESSING_LINE="             \033[0K\r"
 
+# Check if we have a key path first
+if [[ -f "$OPENAI_API_KEY_PATH" ]]; then
+	# Set the key value to OPENAI_KEY
+	export OPENAI_KEY="$(cat $OPENAI_API_KEY_PATH)"
+fi
+
 if [[ -z "$OPENAI_KEY" ]]; then
 	echo "You need to set your OPENAI_KEY to use this script"
 	echo "You can set it temporarily by running this on your terminal: export OPENAI_KEY=YOUR_KEY_HERE"
+	echo "You may also specify the path to a key file instead: export OPENAI_API_KEY_PATH=/path/to/your/key.txt"
 	exit 1
 fi
 


### PR DESCRIPTION
- This will allow using chatgpt without having the sensitive API key itself set directly in your environment
