### PR TITLE
pass the output to pipeline to -p

### DIFF
--- a/chatgpt.sh
+++ b/chatgpt.sh
@@ -231,6 +231,13 @@ while [[ "$#" -gt 0 ]]; do
 		;;
 	-p | --prompt)
 		prompt="$2"
+		if ! [ -t 0 ]; then
+			piped_input=""
+			while IFS= read -r line; do
+				piped_input+="$line\n"
+			done
+			prompt="$prompt $piped_input"
+    	fi	
 		shift
 		shift
 		;;


### PR DESCRIPTION
```
Before:
$ cat error.log | chatgpt -p "check the log and provide solution"

I cannot directly check logs. However, if you provide details or describe the issue you're facing,
I can help suggest potential solutions or troubleshooting steps.

after:
$ cat error.log | chatgpt -p "check the log and provide solution"

The log indicates that there were errors while downloading metadata for the
'rhel-9-for-x86_64-appstream-rpms' repository due to a 403 status code. To address this issue, you
can try the following solutions:

1. Check network connectivity: Ensure that the server has a stable internet connection and can
access the repository URL without any restrictions.

2. Repository configuration: Verify the repository configuration for any errors and make necessary
corrections.

```

